### PR TITLE
[IE-532] Ruby 3

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+  "name": "minimal_ubuntu",
+  "image": "ruby:3.0.6"
+}

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,0 +1,32 @@
+name: Tests
+
+on: [pull_request]
+
+jobs:
+  rspec:
+    runs-on: ubuntu-latest
+    environment: test
+    container:
+      image: ruby:3.0.6
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Gem cache
+        id: cache-bundle
+        uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: bundle-${{ hashFiles('**/Gemfile.lock') }}
+
+      - name: Bundle install
+        env:
+          RAILS_ENV: test
+        run: |
+          bundle install
+
+      - name: Run tests
+        env:
+          RAILS_ENV: test
+        run: |
+          bundle exec rspec

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,6 @@
 
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:
-Gemfile.lock
 .ruby-version
 .ruby-gemset
+.tool-versions

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,88 @@
+PATH
+  remote: .
+  specs:
+    microsoft_project (0.1.1)
+      activesupport (>= 4.2.11.1)
+      nokogiri (~> 1.10)
+      ruby-duration (~> 3.2, >= 3.2.3)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (7.1.3)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      mutex_m
+      tzinfo (~> 2.0)
+    ast (2.4.2)
+    base64 (0.2.0)
+    bigdecimal (3.1.6)
+    concurrent-ruby (1.2.3)
+    connection_pool (2.4.1)
+    diff-lcs (1.5.1)
+    drb (2.2.0)
+      ruby2_keywords
+    i18n (1.14.1)
+      concurrent-ruby (~> 1.0)
+    iso8601 (0.13.0)
+    minitest (5.22.2)
+    mutex_m (0.2.0)
+    nokogiri (1.16.2-arm64-darwin)
+      racc (~> 1.4)
+    parallel (1.24.0)
+    parser (3.3.0.5)
+      ast (~> 2.4.1)
+      racc
+    racc (1.7.3)
+    rainbow (3.1.1)
+    regexp_parser (2.9.0)
+    rexml (3.2.6)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.0)
+    rubocop (0.93.1)
+      parallel (~> 1.10)
+      parser (>= 2.7.1.5)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8)
+      rexml
+      rubocop-ast (>= 0.6.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
+    ruby-duration (3.2.3)
+      activesupport (>= 3.0.0)
+      i18n
+      iso8601
+    ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (1.8.0)
+
+PLATFORMS
+  arm64-darwin-22
+
+DEPENDENCIES
+  microsoft_project!
+  rspec (~> 3)
+  rubocop (~> 0.74)
+
+BUNDLED WITH
+   2.3.22

--- a/lib/microsoft_project/version.rb
+++ b/lib/microsoft_project/version.rb
@@ -1,3 +1,3 @@
 module MicrosoftProject
-  VERSION = "0.1.0".freeze
+  VERSION = "0.1.1".freeze
 end


### PR DESCRIPTION
To make sure Konekti dependencies are ready for Ruby 3 we are updating their stacks and fixing any problems we find in the way. 

This PR aims to adjust gems to new pattern that we are setting with dev options and a unified CI file.