### PR TITLE
Bump rexml from 3.2.6 to 3.3.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,8 @@ GEM
     racc (1.7.3)
     rainbow (3.1.1)
     regexp_parser (2.9.0)
-    rexml (3.2.6)
+    rexml (3.3.4)
+      strscan
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -74,6 +75,7 @@ GEM
       iso8601
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    strscan (3.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.8.0)
@@ -88,4 +90,4 @@ DEPENDENCIES
   rubocop (~> 0.74)
 
 BUNDLED WITH
-   2.3.22
+   2.4.22


### PR DESCRIPTION
Addresses https://github.com/mavenlink-solutions/microsoft_project/security/dependabot/7, https://github.com/mavenlink-solutions/microsoft_project/security/dependabot/6, https://github.com/mavenlink-solutions/microsoft_project/security/dependabot/5, and https://github.com/mavenlink-solutions/microsoft_project/security/dependabot/4